### PR TITLE
Updated examples + worker

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -54,15 +54,17 @@ export const Sidebar = (props: {
           <div className="mt-3 text-xl font-bold text-gray-900 lg:hidden">
             Table of Contents
           </div>
-          <div className="mt-2 text-sm text-gray-600">
-            Last refreshed {new Date(props.timestamp).toLocaleString()}.{" "}
-            <a
-              className="text-sm cursor-pointer link"
-              onClick={props.forceReload}
-            >
-              Refresh now
-            </a>
-          </div>
+          {props.timestamp ? (
+            <div className="mt-2 text-sm text-gray-600">
+              Last refreshed {new Date(props.timestamp).toLocaleString()}.{" "}
+              <a
+                className="text-sm cursor-pointer link"
+                onClick={props.forceReload}
+              >
+                Refresh now
+              </a>
+            </div>
+          ) : null}
         </header>
       ) : null}
       <nav className="px-4 py-2 sm:px-6">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,9 +6,9 @@ import Link from "next/link";
 import { useState } from "react";
 
 const examples = [
-  "deno.land/std/http/mod.ts",
+  "deno.land/std/http/server.ts",
   "deno.land/std/fs/copy.ts",
-  "deno.land/x/oak/mod.ts",
+  "deno.land/x/oak/application.ts",
 ];
 
 const Home = () => {

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,6 +1,6 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 
-const origin = "https://deno-doc.lucacasonato.now.sh/api/docs";
+const origin = "https://doc-website.denoland.now.sh/api/docs";
 
 async function handleRequest(event) {
   let request = event.request;

--- a/worker/package.json
+++ b/worker/package.json
@@ -2,15 +2,7 @@
   "private": true,
   "name": "worker",
   "version": "1.0.0",
-  "description": "A template for kick starting a Cloudflare Workers project",
+  "description": "Cloudflare Worker for doc.deno.land",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "format": "prettier --write '**/*.{js,css,json,md}'"
-  },
-  "author": "Luca Casonato <lucacasonato@yahoo.com>",
-  "license": "MIT",
-  "devDependencies": {
-    "prettier": "^1.18.2"
-  }
+  "license": "MIT"
 }

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,6 +1,6 @@
 name = "deno_doc_cache"
 type = "javascript"
-account_id = "93bfcf72dfea0e9f2bf5563bc71052cf"
+account_id = "895762025d37fc687ecd72d7cc80204a"
 workers_dev = false
-route = "https://denodoc.lcas.dev/api/docs*"
-zone_id = "0ce0e4d3281b88d402b5e7b874f99d2f"
+route = "https://doc.deno.land/api/docs*"
+zone_id = "c192cf8ac042c681023493c52edd44c8"


### PR DESCRIPTION
Updated examples.

@ry There is also a Cloudflare Worker that belongs to the site (for caching). It's in the `//worker` folder. I set it up with all of the correct IDs already for your CF account already, you just need to deploy it to CF and enable the 'proxy thru cloudflare' setting (the orange cloud in the DNS panel) for the `doc.deno.land` subdomain. (once this is merged)