### PR TITLE
Add .vercel to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ yarn-error.log*
 .env.production.local
 
 .now
+.vercel


### PR DESCRIPTION
`.vercel` gets added to `.gitignore` while running `now`

```console
$ now
Now CLI 19.0.1
? Set up and deploy “~/workspace/doc_website”? [Y/n] y
? Which scope do you want to deploy to? trivikr
? Found project “trivikr/doc-website”. Link to it? [Y/n] y
🔗  Linked to trivikr/doc-website (created .vercel and added it to .gitignore)
```