### PR TITLE
Improve how source URL is displayed

### DIFF
--- a/components/SinglePage.tsx
+++ b/components/SinglePage.tsx
@@ -94,24 +94,7 @@ export const CardList = memo(
       <>
         {groups.functions.length > 0 ? (
           <div>
-            <div
-              className={
-                "text-gray-900 font-medium mb-1 " +
-                (nested ? "text-md mt-2" : "text-2xl")
-              }
-            >
-              Functions{" "}
-              {nested ? (
-                ""
-              ) : (
-                <a
-                  className="break-words cursor-pointer text-sm"
-                  href={sourceUrl}
-                >
-                  [src]
-                </a>
-              )}
-            </div>
+            <CardLabel name="Function" sourceUrl={sourceUrl} nested={nested} />
             <div>
               {groups.functions.map((node, i) => (
                 <FunctionCard
@@ -125,24 +108,7 @@ export const CardList = memo(
         ) : null}
         {groups.variables.length > 0 ? (
           <div>
-            <div
-              className={
-                "text-gray-900 font-medium mb-1 " +
-                (nested ? "text-md mt-2" : "text-2xl")
-              }
-            >
-              Variables{" "}
-              {nested ? (
-                ""
-              ) : (
-                <a
-                  className="break-words cursor-pointer link text-sm"
-                  href={sourceUrl}
-                >
-                  [src]
-                </a>
-              )}
-            </div>
+            <CardLabel name="Variables" sourceUrl={sourceUrl} nested={nested} />
             <div>
               {groups.variables.map((node, i) => (
                 <VariableCard
@@ -156,24 +122,7 @@ export const CardList = memo(
         ) : null}
         {groups.classes.length > 0 ? (
           <div>
-            <div
-              className={
-                "text-gray-900 font-medium mb-1 " +
-                (nested ? "text-md mt-2" : "text-2xl")
-              }
-            >
-              Classes{" "}
-              {nested ? (
-                ""
-              ) : (
-                <a
-                  className="break-words cursor-pointer link text-sm"
-                  href={sourceUrl}
-                >
-                  [src]
-                </a>
-              )}
-            </div>
+            <CardLabel name="Classes" sourceUrl={sourceUrl} nested={nested} />
             <div>
               {groups.classes.map((node, i) => (
                 <ClassCard
@@ -187,24 +136,7 @@ export const CardList = memo(
         ) : null}
         {groups.enums.length > 0 ? (
           <div>
-            <div
-              className={
-                "text-gray-900 font-medium mb-1 " +
-                (nested ? "text-md mt-2" : "text-2xl")
-              }
-            >
-              Enums{" "}
-              {nested ? (
-                ""
-              ) : (
-                <a
-                  className="break-words cursor-pointer link text-sm"
-                  href={sourceUrl}
-                >
-                  [src]
-                </a>
-              )}
-            </div>
+            <CardLabel name="Enums" sourceUrl={sourceUrl} nested={nested} />
             <div>
               {groups.enums.map((node, i) => (
                 <EnumCard
@@ -218,24 +150,11 @@ export const CardList = memo(
         ) : null}
         {groups.interfaces.length > 0 ? (
           <div>
-            <div
-              className={
-                "text-gray-900 font-medium mb-1 " +
-                (nested ? "text-md mt-2" : "text-2xl")
-              }
-            >
-              Interfaces{" "}
-              {nested ? (
-                ""
-              ) : (
-                <a
-                  className="break-words cursor-pointer link text-sm"
-                  href={sourceUrl}
-                >
-                  [src]
-                </a>
-              )}
-            </div>
+            <CardLabel
+              name="Interfaces"
+              sourceUrl={sourceUrl}
+              nested={nested}
+            />
             <div>
               {groups.interfaces.map((node, i) => (
                 <InterfaceCard
@@ -249,24 +168,11 @@ export const CardList = memo(
         ) : null}
         {groups.typeAliases.length > 0 ? (
           <div>
-            <div
-              className={
-                "text-gray-900 font-medium mb-1 " +
-                (nested ? "text-md mt-2" : "text-2xl")
-              }
-            >
-              Type Aliases{" "}
-              {nested ? (
-                ""
-              ) : (
-                <a
-                  className="break-words cursor-pointer link text-sm"
-                  href={sourceUrl}
-                >
-                  [src]
-                </a>
-              )}
-            </div>
+            <CardLabel
+              name="Type Aliases"
+              sourceUrl={sourceUrl}
+              nested={nested}
+            />
             <div>
               {groups.typeAliases.map((node, i) => (
                 <TypeAliasCard
@@ -280,24 +186,11 @@ export const CardList = memo(
         ) : null}
         {groups.namespaces.length > 0 ? (
           <div>
-            <div
-              className={
-                "text-gray-900 font-medium mb-1 " +
-                (nested ? "text-md mt-2" : "text-2xl")
-              }
-            >
-              Namespaces{" "}
-              {nested ? (
-                ""
-              ) : (
-                <a
-                  className="break-words cursor-pointer link text-sm"
-                  href={sourceUrl}
-                >
-                  [src]
-                </a>
-              )}
-            </div>
+            <CardLabel
+              name="Namespaces"
+              sourceUrl={sourceUrl}
+              nested={nested}
+            />
             <div>
               {groups.namespaces.map((node, i) => (
                 <NamespaceCard
@@ -447,6 +340,34 @@ export function SimpleSubCard({
           <JSDoc jsdoc={node.jsDoc} />
         </div>
       ) : null}
+    </div>
+  );
+}
+
+export function CardLabel({
+  name,
+  sourceUrl,
+  nested,
+}: {
+  name: string;
+  sourceUrl?: string;
+  nested?: boolean;
+}) {
+  return (
+    <div
+      className={
+        "text-gray-900 font-medium mb-1 " +
+        (nested ? "text-md mt-2" : "text-2xl")
+      }
+    >
+      {name}{" "}
+      {nested ? (
+        ""
+      ) : (
+        <a className="break-words cursor-pointer text-sm" href={sourceUrl}>
+          [src]
+        </a>
+      )}
     </div>
   );
 }

--- a/components/SinglePage.tsx
+++ b/components/SinglePage.tsx
@@ -105,7 +105,7 @@ export const CardList = memo(
                 ""
               ) : (
                 <a
-                  className="break-words cursor-pointer link text-sm"
+                  className="break-words cursor-pointer text-sm"
                   href={sourceUrl}
                 >
                   [src]
@@ -128,10 +128,20 @@ export const CardList = memo(
             <div
               className={
                 "text-gray-900 font-medium mb-1 " +
-                (nested ? "text-md mt-2" : "text-2xl mt-4")
+                (nested ? "text-md mt-2" : "text-2xl")
               }
             >
-              Variables
+              Variables{" "}
+              {nested ? (
+                ""
+              ) : (
+                <a
+                  className="break-words cursor-pointer link text-sm"
+                  href={sourceUrl}
+                >
+                  [src]
+                </a>
+              )}
             </div>
             <div>
               {groups.variables.map((node, i) => (
@@ -149,10 +159,20 @@ export const CardList = memo(
             <div
               className={
                 "text-gray-900 font-medium mb-1 " +
-                (nested ? "text-md mt-2" : "text-2xl mt-4")
+                (nested ? "text-md mt-2" : "text-2xl")
               }
             >
-              Classes
+              Classes{" "}
+              {nested ? (
+                ""
+              ) : (
+                <a
+                  className="break-words cursor-pointer link text-sm"
+                  href={sourceUrl}
+                >
+                  [src]
+                </a>
+              )}
             </div>
             <div>
               {groups.classes.map((node, i) => (
@@ -170,10 +190,20 @@ export const CardList = memo(
             <div
               className={
                 "text-gray-900 font-medium mb-1 " +
-                (nested ? "text-md mt-2" : "text-2xl mt-4")
+                (nested ? "text-md mt-2" : "text-2xl")
               }
             >
-              Enums
+              Enums{" "}
+              {nested ? (
+                ""
+              ) : (
+                <a
+                  className="break-words cursor-pointer link text-sm"
+                  href={sourceUrl}
+                >
+                  [src]
+                </a>
+              )}
             </div>
             <div>
               {groups.enums.map((node, i) => (
@@ -191,10 +221,20 @@ export const CardList = memo(
             <div
               className={
                 "text-gray-900 font-medium mb-1 " +
-                (nested ? "text-md mt-2" : "text-2xl mt-4")
+                (nested ? "text-md mt-2" : "text-2xl")
               }
             >
-              Interfaces
+              Interfaces{" "}
+              {nested ? (
+                ""
+              ) : (
+                <a
+                  className="break-words cursor-pointer link text-sm"
+                  href={sourceUrl}
+                >
+                  [src]
+                </a>
+              )}
             </div>
             <div>
               {groups.interfaces.map((node, i) => (
@@ -212,10 +252,20 @@ export const CardList = memo(
             <div
               className={
                 "text-gray-900 font-medium mb-1 " +
-                (nested ? "text-md mt-2" : "text-2xl mt-4")
+                (nested ? "text-md mt-2" : "text-2xl")
               }
             >
-              Type Aliases
+              Type Aliases{" "}
+              {nested ? (
+                ""
+              ) : (
+                <a
+                  className="break-words cursor-pointer link text-sm"
+                  href={sourceUrl}
+                >
+                  [src]
+                </a>
+              )}
             </div>
             <div>
               {groups.typeAliases.map((node, i) => (
@@ -233,10 +283,20 @@ export const CardList = memo(
             <div
               className={
                 "text-gray-900 font-medium mb-1 " +
-                (nested ? "text-md mt-2" : "text-2xl mt-4")
+                (nested ? "text-md mt-2" : "text-2xl")
               }
             >
-              Namespaces
+              Namespaces{" "}
+              {nested ? (
+                ""
+              ) : (
+                <a
+                  className="break-words cursor-pointer link text-sm"
+                  href={sourceUrl}
+                >
+                  [src]
+                </a>
+              )}
             </div>
             <div>
               {groups.namespaces.map((node, i) => (

--- a/components/SinglePage.tsx
+++ b/components/SinglePage.tsx
@@ -63,18 +63,12 @@ export const SinglePage = memo(
         >
           <div className="max-w-4xl px-4 pb-3 bg-gray-100 sm:px-6">
             <div className="py-4">
-              <a
-                className="break-words cursor-pointer link"
-                href={props.entrypoint}
-              >
-                {props.entrypoint}
-              </a>
               {hasNone ? (
                 <h1 className="pt-4 pb-1 text-xl text-gray-900 ">
                   This module has no exports that are recognized by deno doc.
                 </h1>
               ) : (
-                <CardList nodes={nodes} />
+                <CardList nodes={nodes} sourceUrl={props.entrypoint} />
               )}
             </div>
           </div>
@@ -85,7 +79,15 @@ export const SinglePage = memo(
 );
 
 export const CardList = memo(
-  ({ nodes, nested }: { nodes: DocNode[]; nested?: boolean }) => {
+  ({
+    nodes,
+    sourceUrl,
+    nested,
+  }: {
+    nodes: DocNode[];
+    sourceUrl?: string;
+    nested?: boolean;
+  }) => {
     const groups = useMemo(() => groupNodes(sortByAlphabet(nodes)), [nodes]);
 
     return (
@@ -95,10 +97,20 @@ export const CardList = memo(
             <div
               className={
                 "text-gray-900 font-medium mb-1 " +
-                (nested ? "text-md mt-2" : "text-2xl mt-4")
+                (nested ? "text-md mt-2" : "text-2xl")
               }
             >
-              Functions
+              Functions{" "}
+              {nested ? (
+                ""
+              ) : (
+                <a
+                  className="break-words cursor-pointer link text-sm"
+                  href={sourceUrl}
+                >
+                  [src]
+                </a>
+              )}
             </div>
             <div>
               {groups.functions.map((node, i) => (


### PR DESCRIPTION
Improve how doc's source URL is displayed as specified in https://github.com/denoland/doc_website/issues/103

Screenshots:
![Screenshot 2020-05-30 at 14 57 35](https://user-images.githubusercontent.com/7852866/83330432-c6a15280-a286-11ea-812c-b7826fd61905.png)
