### PR TITLE
Move document source URL to sidebar

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -60,6 +60,11 @@ export const Sidebar = (props: {
             </div>
           ) : null}
           <p className="mt-2 text-sm">
+            <a className="link" href={props.entrypoint}>
+              Documentation Source
+            </a>
+          </p>
+          <p className="mt-2 text-sm">
             <Link href="/about">
               <a className="link">About doc.deno.land</a>
             </Link>

--- a/components/SinglePage.tsx
+++ b/components/SinglePage.tsx
@@ -63,12 +63,6 @@ export const SinglePage = memo(
         >
           <div className="max-w-4xl px-4 pb-3 bg-gray-100 sm:px-6">
             <div className="py-4">
-              <a
-                className="break-words cursor-pointer link"
-                href={props.entrypoint}
-              >
-                {props.entrypoint}
-              </a>
               {hasNone ? (
                 <h1 className="pt-4 pb-1 text-xl text-gray-900 ">
                   This module has no exports that are recognized by deno doc.


### PR DESCRIPTION
Improves how source URL is displayed as specified in https://github.com/denoland/doc_website/issues/103

Screenshots:
![Screenshot 2020-05-30 at 15 51 45](https://user-images.githubusercontent.com/7852866/83331365-c5bfef00-a28d-11ea-9e17-c06c50f774e3.png)
