### PR TITLE
feat: link to Deno builtins from modules

### DIFF
--- a/components/Class.tsx
+++ b/components/Class.tsx
@@ -8,7 +8,7 @@ import {
   TsTypeParamDef,
 } from "../util/docs";
 import { SimpleCard, SimpleSubCard } from "./SinglePage";
-import { useFlattend } from "../util/data";
+import { useFlattend, useRuntimeBuiltins } from "../util/data";
 import Link from "next/link";
 import { TsType, LinkRef } from "./TsType";
 
@@ -39,8 +39,9 @@ export function ClassCard({
   const parent = node;
 
   const { extends: extends_ } = node.classDef;
+  const runtimeBuiltins = useRuntimeBuiltins();
   const extendsLink = extends_
-    ? getLinkByScopedName(flattend, extends_, node.scope ?? [])
+    ? getLinkByScopedName(flattend, runtimeBuiltins, extends_, node.scope ?? [])
     : undefined;
 
   return (

--- a/components/Documentation.tsx
+++ b/components/Documentation.tsx
@@ -29,6 +29,24 @@ export const Documentation = ({
     }
   );
 
+  const { data: runtimeBuiltinsData } = useSWR<DocsData>(
+    [loadCount],
+    () =>
+      getData(
+        "https://github.com/denoland/deno/releases/latest/download/lib.deno.d.ts",
+        "",
+        loadCount > 0
+      ).catch((err) => {
+        throw err?.message ?? err.toString();
+      }),
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      refreshWhenHidden: false,
+      refreshWhenOffline: false,
+    }
+  );
+
   useEffect(() => {
     let { hash } = location;
     hash = hash && hash.substring(1);
@@ -85,6 +103,7 @@ export const Documentation = ({
         forceReload={forceReload}
         entrypoint={entrypoint}
         data={data}
+        runtimeBuiltinsData={runtimeBuiltinsData}
       />
     </>
   );

--- a/components/SinglePage.tsx
+++ b/components/SinglePage.tsx
@@ -1,7 +1,11 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 
 import React, { useMemo, memo } from "react";
-import { DocsData, FlattendProvider } from "../util/data";
+import {
+  DocsData,
+  FlattendProvider,
+  RuntimeBuiltinsProvider,
+} from "../util/data";
 import {
   groupNodes,
   DocNodeShared,
@@ -30,9 +34,8 @@ export const SinglePage = memo(
     forceReload: () => void;
     entrypoint: string;
     data: DocsData | undefined;
+    runtimeBuiltinsData: DocsData | undefined;
   }) => {
-    const nodes = expandNamespaces(props.data?.nodes ?? []);
-
     if (!props.data) {
       return (
         <Wrapper
@@ -50,36 +53,46 @@ export const SinglePage = memo(
       );
     }
 
+    const nodes = expandNamespaces(props.data.nodes ?? []);
+    const runtimeBuiltinsNodes = props.runtimeBuiltinsData
+      ? expandNamespaces(props.runtimeBuiltinsData.nodes)
+      : undefined;
+
     const hasNone = nodes.length === 0;
 
     const flattend = flattenNamespaces(nodes);
+    const flattendRuntimeBuiltins = runtimeBuiltinsNodes
+      ? flattenNamespaces(runtimeBuiltinsNodes)
+      : undefined;
 
     return (
-      <FlattendProvider value={flattend}>
-        <Wrapper
-          forceReload={props.forceReload}
-          entrypoint={props.entrypoint}
-          timestamp={props.data.timestamp}
-        >
-          <div className="max-w-screen-lg px-4 sm:px-6 md:px-8 pb-12">
-            <div className="py-6">
-              <a
-                className="break-words cursor-pointer link"
-                href={props.entrypoint}
-              >
-                {props.entrypoint}
-              </a>
-              {hasNone ? (
-                <h1 className="pt-4 pb-1 text-xl text-gray-900 dark:text-gray-200">
-                  This module has no exports that are recognized by deno doc.
-                </h1>
-              ) : (
-                <CardList nodes={nodes} />
-              )}
+      <RuntimeBuiltinsProvider value={flattendRuntimeBuiltins}>
+        <FlattendProvider value={flattend}>
+          <Wrapper
+            forceReload={props.forceReload}
+            entrypoint={props.entrypoint}
+            timestamp={props.data.timestamp}
+          >
+            <div className="max-w-screen-lg px-4 sm:px-6 md:px-8 pb-12">
+              <div className="py-6">
+                <a
+                  className="break-words cursor-pointer link"
+                  href={props.entrypoint}
+                >
+                  {props.entrypoint}
+                </a>
+                {hasNone ? (
+                  <h1 className="pt-4 pb-1 text-xl text-gray-900 dark:text-gray-200">
+                    This module has no exports that are recognized by deno doc.
+                  </h1>
+                ) : (
+                  <CardList nodes={nodes} />
+                )}
+              </div>
             </div>
-          </div>
-        </Wrapper>
-      </FlattendProvider>
+          </Wrapper>
+        </FlattendProvider>
+      </RuntimeBuiltinsProvider>
     );
   }
 );

--- a/components/TsType.tsx
+++ b/components/TsType.tsx
@@ -7,8 +7,9 @@ import {
   LiteralDefKind,
   getLinkByScopedName,
 } from "../util/docs";
-import { useFlattend } from "../util/data";
+import { useFlattend, useRuntimeBuiltins } from "../util/data";
 import { Params } from "./Function";
+import Link from "next/link";
 
 export const TsType = memo(
   ({ tsType, scope }: { tsType: TsTypeDef; scope: string[] }) => {
@@ -177,8 +178,10 @@ export const TsType = memo(
         );
       case TsTypeDefKind.TypeQuery: {
         const flattend = useFlattend();
+        const runtimeBuiltins = useRuntimeBuiltins();
         const link = getLinkByScopedName(
           flattend,
+          runtimeBuiltins,
           tsType.typeQuery,
           scope ?? []
         );
@@ -190,8 +193,10 @@ export const TsType = memo(
       }
       case TsTypeDefKind.TypeRef: {
         const flattend = useFlattend();
+        const runtimeBuiltins = useRuntimeBuiltins();
         const link = getLinkByScopedName(
           flattend,
+          runtimeBuiltins,
           tsType.typeRef.typeName,
           scope ?? [],
           "type"
@@ -234,11 +239,17 @@ export function LinkRef(props: {
 }) {
   switch (props.link?.type) {
     case "local":
-    case "mdn":
+    case "external":
       return (
         <a className="link" href={props.link.href}>
           {props.name}
         </a>
+      );
+    case "builtin":
+      return (
+        <Link href={`/builtin/stable${props.link.href}`}>
+          <a className="link">{props.name}</a>
+        </Link>
       );
     default:
       return <>{props.name}</>;

--- a/pages/builtin/[version].tsx
+++ b/pages/builtin/[version].tsx
@@ -1,0 +1,23 @@
+// Copyright 2020 the Deno authors. All rights reserved. MIT license.
+
+import { useRouter } from "next/router";
+import { Documentation } from "../../components/Documentation";
+
+const Page = () => {
+  const { query } = useRouter();
+  const version = query.version ?? "stable";
+  return (
+    <Documentation
+      entrypoint={
+        version == "stable"
+          ? "https://github.com/denoland/deno/releases/latest/download/lib.deno.d.ts"
+          : version === "unstable"
+          ? "https://raw.githubusercontent.com/denoland/deno/master/cli/dts/lib.deno.unstable.d.ts"
+          : `https://github.com/denoland/deno/releases/download/${version}/lib.deno.d.ts`
+      }
+      name={`builtin@${version}`}
+    />
+  );
+};
+
+export default Page;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -42,10 +42,7 @@ function Home() {
           <Header />
           <div className="max-w-screen-sm mx-auto px-4 sm:px-6 md:px-8 pt-4 sm:pt-12 pb-12 sm:pb-20 flex flex-col items-center">
             <span className="block w-full rounded-md shadow-sm ">
-              <Link
-                href="/https/[...url]"
-                as={`/https/github.com/denoland/deno/releases/latest/download/lib.deno.d.ts`}
-              >
+              <Link href="/builtin/[version]" as={`/builtin/stable`}>
                 <a
                   type="submit"
                   className="w-full flex justify-center py-2 px-4 border border-gray-300 dark:border-light-black-700 dark:hover:border-light-black-600 text-md font-medium rounded-md text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-light-black-800 hover:text-gray-500 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-light-black-700 focus:outline-none focus:shadow-outline-gray focus:border-gray-600 active:bg-gray-100 dark:active:bg-light-black-700 active:text-gray-700 dark:active:text-gray-100 transition duration-150 ease-in-out"
@@ -103,10 +100,7 @@ function Home() {
               --unstable
             </code>{" "}
             runtime documentation{" "}
-            <Link
-              href="/https/[...url]"
-              as={`/https/raw.githubusercontent.com/denoland/deno/master/cli/dts/lib.deno.unstable.d.ts`}
-            >
+            <Link href="/builtin/[version]" as={`/builtin/unstable`}>
               <a className="link"> here</a>
             </Link>
             .

--- a/util/data.ts
+++ b/util/data.ts
@@ -12,6 +12,14 @@ export function useFlattend() {
 
 export const FlattendProvider = flattendContext.Provider;
 
+const runtimeBuiltinsContext = createContext<DocNode[] | undefined>([]);
+
+export function useRuntimeBuiltins() {
+  return useContext(runtimeBuiltinsContext);
+}
+
+export const RuntimeBuiltinsProvider = runtimeBuiltinsContext.Provider;
+
 export interface DocsData {
   timestamp: string;
   nodes: DocNode[];
@@ -20,12 +28,12 @@ export interface DocsData {
 export async function getData(
   entrypoint: string,
   hostname: string,
-  forceReload?: boolean
+  forceReload?: boolean,
 ): Promise<DocsData> {
   const req = await fetch(
     `${hostname}/api/docs?entrypoint=${encodeURIComponent(entrypoint)}${
       forceReload ? "&force_reload=true" : ""
-    }`
+    }`,
   );
   if (!req.ok) throw new Error((await req.json()).error);
   const resp = await req.json();


### PR DESCRIPTION
Builtins are now also served from `/builtin/stable`, `/builtin/unstable`, and `/builtin/[version]`.
