### PR TITLE
Fix padding

### DIFF
--- a/components/Wrapper.tsx
+++ b/components/Wrapper.tsx
@@ -88,7 +88,7 @@ export function Wrapper(props: {
                     </a>
                   </Link>
                   {flattend ? (
-                    <header className="px-4 pt-3 sm:px-6 sm:pt-4">
+                    <header className="p-4">
                       {props.timestamp ? (
                         <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
                           Last refreshed{" "}
@@ -132,7 +132,7 @@ export function Wrapper(props: {
               </a>
             </Link>
             {flattend ? (
-              <header className="px-4 pt-3 sm:px-6 sm:pt-4">
+              <header className="p-4">
                 {props.timestamp ? (
                   <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
                     Last refreshed {new Date(props.timestamp).toLocaleString()}.{" "}


### PR DESCRIPTION
Fix up the padding and use same through /x and on the docs.

From:
<img width="280" alt="Screenshot 2020-08-13 at 11 28 18" src="https://user-images.githubusercontent.com/32820112/90124378-2f617c80-dd58-11ea-996c-aa3c13450996.png">

To:
<img width="277" alt="Screenshot 2020-08-13 at 11 28 09" src="https://user-images.githubusercontent.com/32820112/90124402-36888a80-dd58-11ea-8109-a1897aa5e816.png">
