### PR TITLE
Padding wrapper fix

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,7 +19,7 @@ const Header = () => {
             />
             <div className="ml-5 flex flex-col justify-center">
               <div className="font-bold text-gray-900 dark:text-gray-200 leading-tight text-2xl sm:text-3xl tracking-tight">
-                deno doc
+                Deno Doc
               </div>
               <div className="font-normal text-gray-900 dark:text-gray-200 text-sm sm:text-lg leading-tight tracking-tight">
                 Documentation Generator
@@ -110,7 +110,7 @@ const Header = () => {
                     />
                     <div className="ml-5 flex flex-col justify-center">
                       <div className="font-bold text-gray-900 dark:text-gray-200 leading-tight text-2xl sm:text-3xl tracking-tight">
-                        deno doc
+                        Deno Doc
                       </div>
                       <div className="font-normal text-gray-900 dark:text-gray-200 text-sm sm:text-lg leading-tight tracking-tight">
                         Documentation Generator

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,7 +19,7 @@ const Header = () => {
             />
             <div className="ml-5 flex flex-col justify-center">
               <div className="font-bold text-gray-900 dark:text-gray-200 leading-tight text-2xl sm:text-3xl tracking-tight">
-                Deno Doc
+                deno doc
               </div>
               <div className="font-normal text-gray-900 dark:text-gray-200 text-sm sm:text-lg leading-tight tracking-tight">
                 Documentation Generator
@@ -110,7 +110,7 @@ const Header = () => {
                     />
                     <div className="ml-5 flex flex-col justify-center">
                       <div className="font-bold text-gray-900 dark:text-gray-200 leading-tight text-2xl sm:text-3xl tracking-tight">
-                        Deno Doc
+                        deno doc
                       </div>
                       <div className="font-normal text-gray-900 dark:text-gray-200 text-sm sm:text-lg leading-tight tracking-tight">
                         Documentation Generator

--- a/components/Wrapper.tsx
+++ b/components/Wrapper.tsx
@@ -88,7 +88,7 @@ export function Wrapper(props: {
                     </a>
                   </Link>
                   {flattend ? (
-                    <header className="p-4">
+                    <header className="pt-4 pb-2 px-4">
                       {props.timestamp ? (
                         <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
                           Last refreshed{" "}
@@ -132,7 +132,7 @@ export function Wrapper(props: {
               </a>
             </Link>
             {flattend ? (
-              <header className="p-4">
+              <header className="pt-4 pb-2 px-4">
                 {props.timestamp ? (
                   <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
                     Last refreshed {new Date(props.timestamp).toLocaleString()}.{" "}

--- a/components/Wrapper.tsx
+++ b/components/Wrapper.tsx
@@ -82,7 +82,7 @@ export function Wrapper(props: {
                       />
                       <div className="mx-4 flex flex-col justify-center">
                         <div className="font-bold text-gray-900 dark:text-gray-200 leading-6 text-2xl tracking-tight">
-                          Deno Doc
+                          deno doc
                         </div>
                       </div>
                     </a>
@@ -126,7 +126,7 @@ export function Wrapper(props: {
                 <img src="/favicon.svg" alt="logo" className="w-auto h-12" />
                 <div className="mx-4 flex flex-col justify-center">
                   <div className="font-bold text-gray-900 dark:text-gray-200 leading-6 text-2xl tracking-tight">
-                    Deno Doc
+                    deno doc
                   </div>
                 </div>
               </a>

--- a/components/Wrapper.tsx
+++ b/components/Wrapper.tsx
@@ -82,7 +82,7 @@ export function Wrapper(props: {
                       />
                       <div className="mx-4 flex flex-col justify-center">
                         <div className="font-bold text-gray-900 dark:text-gray-200 leading-6 text-2xl tracking-tight">
-                          deno doc
+                          Deno Doc
                         </div>
                       </div>
                     </a>
@@ -126,7 +126,7 @@ export function Wrapper(props: {
                 <img src="/favicon.svg" alt="logo" className="w-auto h-12" />
                 <div className="mx-4 flex flex-col justify-center">
                   <div className="font-bold text-gray-900 dark:text-gray-200 leading-6 text-2xl tracking-tight">
-                    deno doc
+                    Deno Doc
                   </div>
                 </div>
               </a>


### PR DESCRIPTION
Remove 2 lower padding, same padding as manual now.

From:
<img width="294" alt="Screenshot 2020-08-16 at 13 33 44" src="https://user-images.githubusercontent.com/32820112/90334387-39d47e00-dfc5-11ea-941d-2a96cfa475cb.png">

To:
<img width="297" alt="Screenshot 2020-08-16 at 13 34 11" src="https://user-images.githubusercontent.com/32820112/90334390-3ccf6e80-dfc5-11ea-83d9-a27224937af4.png">

Example padding from manual:
<img width="305" alt="Screenshot 2020-08-16 at 13 35 17" src="https://user-images.githubusercontent.com/32820112/90334402-57094c80-dfc5-11ea-88c1-9e5f7ae2c1aa.png">