### PR TITLE
chore: update Deno to 1.8.0

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,12 +8,12 @@
   "regions": ["sfo"],
   "build": {
     "env": {
-      "DENO_VERSION": "1.7.5",
+      "DENO_VERSION": "1.8.0",
       "DENO_UNSTABLE": "true"
     }
   },
   "env": {
-    "DENO_VERSION": "1.7.5",
+    "DENO_VERSION": "1.8.0",
     "DENO_UNSTABLE": "true"
   },
   "github": {

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/**/*.ts": {
-      "runtime": "vercel-deno@0.7.6",
+      "runtime": "vercel-deno@0.7.7",
       "maxDuration": 60
     }
   },


### PR DESCRIPTION
Adds support for `// @deno-types`, `X-TypeScript-Types` and `/// <reference types="..." />`.