### PR TITLE
Support import maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,7 @@ This website is built with [Next.js](https://nextjs.org) and automatically deplo
 
 ### Contributing
 
+You need a Vercel account that you can create for free at https://vercel.com/signup.
+In case you have a free account, you need to change `maxDuration` in the `functions` section of `vercel.json` to a max allowed value for free accounts: `10`.
+
 Install [Vercel CLI](https://vercel.com/download) and run `vercel dev`. Currently not supported on Windows, see (https://github.com/lucacasonato/now-deno/issues/12)

--- a/components/Documentation.tsx
+++ b/components/Documentation.tsx
@@ -10,15 +10,17 @@ import { SinglePage } from "./SinglePage";
 export const Documentation = ({
   entrypoint,
   name,
+  importMap,
 }: {
   entrypoint: string;
   name: string;
+  importMap?: string;
 }) => {
   const [loadCount, forceReload] = useReducer((i) => ++i, 0);
   const { data, error } = useSWR<DocsData, string>(
-    [entrypoint, loadCount],
+    [entrypoint, loadCount, importMap],
     () =>
-      getData(entrypoint, "", loadCount > 0).catch((err) => {
+      getData(entrypoint, "", importMap, loadCount > 0).catch((err) => {
         throw err?.message ?? err.toString();
       }),
     {
@@ -35,6 +37,7 @@ export const Documentation = ({
       getData(
         "https://doc-proxy.deno.dev/builtin/stable",
         "",
+        undefined,
         loadCount > 0
       ).catch((err) => {
         throw err?.message ?? err.toString();

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -69,6 +69,22 @@ function About() {
           </p>
         </div>
         <div className="mt-12">
+          <h3
+            className="text-2xl font-semibold tracking-tight"
+            id="import-maps"
+          >
+            Import maps
+          </h3>
+          <p className="pt-2">
+            deno.doc.land supports{" "}
+            <a href="https://github.com/WICG/import-maps" className="link">
+              import maps
+            </a>
+            . Add <InlineCode>?import_map=$IMPORT_MAP_JSON$</InlineCode> to a
+            doc URL to specify one.
+          </p>
+        </div>
+        <div className="mt-12">
           <h3 className="text-2xl font-semibold tracking-tight" id="badges">
             Badges
           </h3>

--- a/pages/https/[...url].tsx
+++ b/pages/https/[...url].tsx
@@ -3,9 +3,11 @@
 import { Documentation } from "../../components/Documentation";
 import { NextPage } from "next";
 
-const Page: NextPage<{ entrypoint: string; name: string }> = (props) => (
-  <Documentation {...props} />
-);
+const Page: NextPage<{
+  entrypoint: string;
+  name: string;
+  importMap?: string;
+}> = (props) => <Documentation {...props} />;
 
 Page.getInitialProps = async (ctx) => {
   const url =
@@ -14,10 +16,39 @@ Page.getInitialProps = async (ctx) => {
       : ctx.query.url === undefined
       ? ""
       : ctx.query.url.join("/");
+
+  const importMap = validateImportMap(ctx.query["import_map"]);
+
   return {
     entrypoint: "https://" + decodeURIComponent(url),
     name: decodeURIComponent(url),
+    importMap,
   };
 };
 
 export default Page;
+
+function validateImportMap(
+  maybeImportMap: string[] | string | undefined
+): string | undefined {
+  if (typeof maybeImportMap !== "string") return undefined;
+
+  let parsedImportMap;
+  try {
+    parsedImportMap = JSON.parse(maybeImportMap);
+  } catch (err) {
+    console.warn("invalid import map", maybeImportMap, err);
+    return undefined;
+  }
+
+  if ("imports" in parsedImportMap || "scopes" in parsedImportMap) {
+    return maybeImportMap;
+  }
+
+  console.warn(
+    'import map is expected to have "imports" and/or "scopes" fields',
+    maybeImportMap
+  );
+
+  return undefined;
+}


### PR DESCRIPTION
Adds support for:

- **inlined import map:**
https://doc-website-c48bet2rq-denoland.vercel.app/https/gist.githubusercontent.com/vovacodes/65c626be8aec4062feed0f7f38b852d4/raw/cdbb6daeb0a0e0fddeace63f61535a118541d6ab/uses-bare-specifier.ts?import_map=%7B%22imports%22%3A%7B%22react%22%3A%22https%3A%2F%2Fcdn.skypack.dev%2Freact%3Fdts%22%7D%7D

- **relative import map path**:
https://doc-website-c48bet2rq-denoland.vercel.app/https/raw.githubusercontent.com/vovacodes/react-sunbeam/feature/subscription-instead-of-context/packages/react-sunbeam/src/focus/hooks/useOnFocusedChange.ts?import_map=..%2F..%2F..%2Fdocs%2Fimportmap.json

- **absolute import map URL**:
https://doc-website-c48bet2rq-denoland.vercel.app/https/raw.githubusercontent.com/vovacodes/react-sunbeam/feature/subscription-instead-of-context/packages/react-sunbeam/src/focus/hooks/useOnFocusedChange.ts?import_map=https%3A%2F%2Fraw.githubusercontent.com%2Fvovacodes%2Freact-sunbeam%2Ffeature%2Fsubscription-instead-of-context%2Fpackages%2Freact-sunbeam%2Fdocs%2Fimportmap.json

Implements: https://github.com/denoland/deno_doc/issues/93