### PR TITLE
Upgrade deno 1.7.5 -> 1.8.2

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,12 +8,12 @@
   "regions": ["sfo"],
   "build": {
     "env": {
-      "DENO_VERSION": "1.7.5",
+      "DENO_VERSION": "1.8.2",
       "DENO_UNSTABLE": "true"
     }
   },
   "env": {
-    "DENO_VERSION": "1.7.5",
+    "DENO_VERSION": "1.8.2",
     "DENO_UNSTABLE": "true"
   },
   "github": {


### PR DESCRIPTION
This should unblock my work on https://github.com/denoland/doc_website/pull/173 cause I currently see the exceptions about `--unstable` being required when doing `deno doc --import-map`: https://doc-website-c48bet2rq-denoland.vercel.app/https/gist.githubusercontent.com/vovacodes/65c626be8aec4062feed0f7f38b852d4/raw/cdbb6daeb0a0e0fddeace63f61535a118541d6ab/uses-bare-specifier.ts?import_map=%7B%22imports%22%3A%7B%22react%22%3A%22https%3A%2F%2Fcdn.skypack.dev%2Freact%3Fdts%22%7D%7D

It's not a case when I'm running the app locally where I'm using `1.8.2`