### PR TITLE
chore: update to deno 1.8.3 using workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ yarn-error.log*
 
 .now
 .vercel
+
+/tmp/*

--- a/vercel.json
+++ b/vercel.json
@@ -1,19 +1,19 @@
 {
   "functions": {
     "api/**/*.ts": {
-      "runtime": "vercel-deno@0.7.6",
+      "runtime": "vercel-deno@0.7.9",
       "maxDuration": 60
     }
   },
   "regions": ["sfo"],
   "build": {
     "env": {
-      "DENO_VERSION": "1.7.5",
+      "DENO_VERSION": "1.8.3",
       "DENO_UNSTABLE": "true"
     }
   },
   "env": {
-    "DENO_VERSION": "1.7.5",
+    "DENO_VERSION": "1.8.3",
     "DENO_UNSTABLE": "true"
   },
   "github": {


### PR DESCRIPTION
This PR updates deno to v1.8.3 using workaround while fetching typescript file. (Downloads the source file in temp dir first, and then run `deno doc` for that file)