### PR TITLE
fix: fix top page of dark mode

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -20,7 +20,7 @@ export default class DenoDocDocument extends Document {
         <Head>
           <link rel="stylesheet" href="/fonts/inter/inter.css" />
         </Head>
-        <body class="bg-gray-50 dark:bg-light-black-900">
+        <body className="bg-gray-50 dark:bg-light-black-900">
           <Main />
           <NextScript />
         </body>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -20,7 +20,7 @@ export default class DenoDocDocument extends Document {
         <Head>
           <link rel="stylesheet" href="/fonts/inter/inter.css" />
         </Head>
-        <body>
+        <body class="bg-gray-50 dark:bg-light-black-900">
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
Before
<img width="1551" alt="スクリーンショット 2021-04-09 14 18 39" src="https://user-images.githubusercontent.com/613956/114132033-96aeeb00-993e-11eb-8f8f-795bf8ce9d04.png">

After
<img width="1551" alt="スクリーンショット 2021-04-09 14 17 22" src="https://user-images.githubusercontent.com/613956/114132056-a1698000-993e-11eb-9109-3207b1d80b38.png">

closes #155 