### PR TITLE
fix: encode URLs entered in the text field

### DIFF
--- a/components/SinglePage.tsx
+++ b/components/SinglePage.tsx
@@ -296,7 +296,11 @@ export function SimpleCard({
           {suffix}
         </div>
         <a
-          href={normalizeFilename(node.location.filename) + "#L" + node.location.line}
+          href={
+            normalizeFilename(node.location.filename) +
+            "#L" +
+            node.location.line
+          }
           className="pl-2 text-gray-600 dark:text-gray-400 break-words hover:text-gray-800 dark:hover:text-gray-200 hover:underline"
         >
           [src]
@@ -369,7 +373,11 @@ export function SimpleSubCard({
         </div>
         {node.location ? (
           <a
-            href={normalizeFilename(node.location.filename) + "#L" + node.location.line}
+            href={
+              normalizeFilename(node.location.filename) +
+              "#L" +
+              node.location.line
+            }
             className="pl-2 text-xs text-gray-600 dark:text-gray-400 break-words hover:text-gray-800 dark:hover:text-gray-200 hover:underline"
           >
             [src]

--- a/pages/https/[...url].tsx
+++ b/pages/https/[...url].tsx
@@ -14,7 +14,10 @@ Page.getInitialProps = async (ctx) => {
       : ctx.query.url === undefined
       ? ""
       : ctx.query.url.join("/");
-  return { entrypoint: "https://" + url, name: url };
+  return {
+    entrypoint: "https://" + decodeURIComponent(url),
+    name: decodeURIComponent(url),
+  };
 };
 
 export default Page;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -24,7 +24,8 @@ function Home() {
   function navigate() {
     router.push(
       "/https/[...url]",
-      "/https/" + url.replace("https://", "").replace("http://", "")
+      "/https/" +
+        encodeURIComponent(url.replace("https://", "").replace("http://", ""))
     );
   }
   return (


### PR DESCRIPTION
Previously, query parameters/fragments in these URLs would be interpreted as part of the url of the page and not the site being documented.

That would then break URLs like `https://cdn.skypack.dev/foo?dts`, because the `?dts` would be dropped and cause the raw JS to be documented with no types.