### PR TITLE
fix(deploy): Don't try to mutate fetch response's headers

### DIFF
--- a/deploy/main.ts
+++ b/deploy/main.ts
@@ -32,14 +32,16 @@ serve({
       return notFound();
     }
     const isBrowser = request.headers.get("accept")?.includes("text/html");
+    // The headers on a `Response` are immutable
+    const headers = new Headers(resp.headers);
     // Responses as plain text to browsers
-    resp.headers.set(
+    headers.set(
       "content-type",
       isBrowser ? "text/plain" : "application/typescript; charset=utf-8",
     );
     // Prevents downloading the file
-    resp.headers.delete("content-disposition");
-    return resp;
+    headers.delete("content-disposition");
+    return new Response(resp.body, { ...resp, headers });
   },
   404: () => notFound(),
 });


### PR DESCRIPTION
Fixes #189

I think they were made immutable when aligning `fetch` to spec in denoland/deno#10203.