### PR TITLE
Put internal server errors in a `<pre>` block

### DIFF
--- a/components/Documentation.tsx
+++ b/components/Documentation.tsx
@@ -74,9 +74,9 @@ export const Documentation = ({
     return (
       <div className="flex flex-col items-center justify-center h-full p-4 text-center bg-white dark:bg-light-black-800">
         <div className="text-3xl text-gray-800 dark:text-gray-200">{title}</div>
-        <div className="mt-2 text-lg text-gray-800 dark:text-gray-200">
+        <pre className="mt-2 text-lg text-gray-800 dark:text-gray-200 text-left bg-gray-100 dark:bg-light-black-600 p-2 rounded-lg w-11/12 max-w-5xl overflow-auto">
           {details}
-        </div>
+        </pre>
         <Link href="/">
           <a className="mt-4 text-xl link">Go back home</a>
         </Link>


### PR DESCRIPTION
This means newlines are properly preserved.

Before:
![image](https://user-images.githubusercontent.com/43807659/117107351-c8dc2d00-adc4-11eb-9636-3858b361c295.png)

After:
![image](https://user-images.githubusercontent.com/43807659/117107369-d09bd180-adc4-11eb-9181-99852b6637a7.png)
