### PR TITLE
using proxy worker for `runtimeBuiltinsData`

### DIFF
--- a/components/Documentation.tsx
+++ b/components/Documentation.tsx
@@ -33,7 +33,7 @@ export const Documentation = ({
     [loadCount],
     () =>
       getData(
-        "https://github.com/denoland/deno/releases/latest/download/lib.deno.d.ts",
+        "https://doc-proxy.deno.dev/builtin/stable",
         "",
         loadCount > 0
       ).catch((err) => {


### PR DESCRIPTION
When visit https://doc.deno.land/builtin/stable, there are 2 requests:

```
https://doc.deno.land/api/docs?entrypoint=https%3A%2F%2Fdoc-proxy.deno.dev%2Fbuiltin%2Fstable ✅
https://doc.deno.land/api/docs?entrypoint=https%3A%2F%2Fgithub.com%2Fdenoland%2Fdeno%2Freleases%2Flatest%2Fdownload%2Flib.deno.d.ts ❌
```

with error:

```
Download https://github.com/denoland/deno/releases/latest/download/lib.deno.d.ts
Download https://github.com/denoland/deno/releases/download/v1.10.1/lib.deno.d.ts
Download https://github-releases.githubusercontent.com/133442384/93a87100-b2d5-11eb-92e9-ba489a7915df?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20210517%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20210517T004956Z&X-Amz-Expires=300&X-Amz-Signature=c7d138f5fe8ac81c8238c24ede40ab2ec53dd8922fabbd6adb3e1cb2a6e4b865&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=133442384&response-content-disposition=attachment%3B%20filename%3Dlib.deno.d.ts&response-content-type=application%2Foctet-stream
error: An unsupported media type was attempted to be imported as a module.
  Specifier: https://github-releases.githubusercontent.com/133442384/93a87100-b2d5-11eb-92e9-ba489a7915df?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20210517%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20210517T004956Z&X-Amz-Expires=300&X-Amz-Signature=c7d138f5fe8ac81c8238c24ede40ab2ec53dd8922fabbd6adb3e1cb2a6e4b865&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=133442384&response-content-disposition=attachment%3B%20filename%3Dlib.deno.d.ts&response-content-type=application%2Foctet-stream
  MediaType: Unknown
```