### PR TITLE
feat: add a display of the "implements" to the class's document

### DIFF
--- a/components/Class.tsx
+++ b/components/Class.tsx
@@ -83,6 +83,21 @@ export function ClassCard({
               ) : null}
             </>
           ) : null}
+          {node.classDef.implements.length ? (
+            <>
+              {" "}
+              <span className="keyword">implements</span>{" "}
+              {node.classDef.implements
+                .map((_implements) => (
+                  <TsType tsType={_implements} scope={node.scope ?? []} />
+                ))
+                .reduce((r, a) => (
+                  <>
+                    {r}, {a}
+                  </>
+                ))}
+            </>
+          ) : null}
         </>
       }
       details={


### PR DESCRIPTION
Currently, "implements" of the class has been ignored. It is useful if I can see this in the documentation.

before: 
![image](https://user-images.githubusercontent.com/40050810/120895478-00eebe00-c658-11eb-80e6-4e4f4a840479.png)

after: 
![image](https://user-images.githubusercontent.com/40050810/120895445-e3b9ef80-c657-11eb-9584-3bbec8135a4f.png)

This is my first time contributing to this repository, so please let me know if I make any mistakes.