### PR TITLE
feat: support user-defined type guards as return type

### DIFF
--- a/components/TsType.tsx
+++ b/components/TsType.tsx
@@ -175,6 +175,30 @@ export const TsType = memo(
             <TsType tsType={tsType.typeOperator.tsType} scope={scope} />
           </>
         );
+      case TsTypeDefKind.TypePredicate: {
+        const predicate = tsType.typePredicate;
+        const paramRepr = predicate.param.type === "this"
+          ? "this"
+          : predicate.param.name;
+        if (predicate.type === null) {
+          if (predicate.asserts) {
+            return (
+              <>
+                asserts {paramRepr}
+              </>
+            );
+          } else {
+            // unreachable - type predicate must have either `asserts` or `is`
+            return null;
+          }
+        }
+        return (
+          <>
+            {predicate.asserts ? "asserts " : ""}
+            {paramRepr} is <TsType tsType={predicate.type} scope={scope} />
+          </>
+        );
+      }
       case TsTypeDefKind.TypeQuery: {
         const flattend = useFlattend();
         const runtimeBuiltins = useRuntimeBuiltins();

--- a/util/docs.ts
+++ b/util/docs.ts
@@ -58,6 +58,16 @@ export interface TsTypeLiteralDef {
   callSignatures: LiteralCallSignatureDef[];
   indexSignatures: LiteralIndexSignatureDef[];
 }
+export interface TsTypePredicateDef {
+  asserts: boolean;
+  param: {
+    type: "this";
+  } | {
+    type: "identifier";
+    name: string;
+  };
+  type: TsTypeDef | null;
+}
 export interface LiteralMethodDef {
   name: string;
   params: ParamDef[];
@@ -118,6 +128,7 @@ export enum TsTypeDefKind {
   Conditional = "conditional",
   IndexedAccess = "indexedAccess",
   TypeLiteral = "typeLiteral",
+  TypePredicate = "typePredicate",
 }
 export interface TsTypeDefShared {
   repr: string;
@@ -157,6 +168,10 @@ export interface TsTypeDefOptional extends TsTypeDefShared {
 export interface TsTypeDefParenthesized extends TsTypeDefShared {
   kind: TsTypeDefKind.Parenthesized;
   parenthesized: TsTypeDef;
+}
+export interface TsTypeDefTypePredicate extends TsTypeDefShared {
+  kind: TsTypeDefKind.TypePredicate;
+  typePredicate: TsTypePredicateDef;
 }
 export interface TsTypeDefRest extends TsTypeDefShared {
   kind: TsTypeDefKind.Rest;
@@ -205,6 +220,7 @@ export type TsTypeDef =
   | TsTypeDefTuple
   | TsTypeDefTypeLiteral
   | TsTypeDefTypeOperator
+  | TsTypeDefTypePredicate
   | TsTypeDefTypeQuery
   | TsTypeDefTypeRef
   | TsTypeDefUnion;


### PR DESCRIPTION
This PR adds support for user-defined type guards as return type.
Fixes #207
Fixes https://github.com/denoland/deno_doc/issues/102

It depends on deno_doc v0.6.0+, so it doesn't work with the current latest version of Deno (1.11.2).
To see it working locally, you have to specify the path to the canary or a binary you built on your own from the latest source. In my case, I changed `api/docs.ts` L27-32 to:

```ts
  const proc = Deno.run({
    cmd: ["/Users/yusuktan/Repos/github.com/magurotuna/deno/target/release/deno", "doc", sourceFile, "--json", "--reload"],
    stdout: "piped",
    stderr: "piped",
    env: { "DENO_DIR": "/tmp/denodir" },
  });
```

then I ran `vercel dev` and attempted to generate doc for the following snippet.

```ts
export function f1(val1: A | B): val1 is A {}
export function f2(val2: any): asserts val2 is string {}
export function f3(val3: any): asserts val3 {}
export function assertIsDefined<T>(val4: T): asserts val4 is NonNullable<T> {
  if (val === undefined || val === null) {
    throw new AssertionError(
      `Expected 'val' to be defined, but received ${val}`
    );
  }
}
export class C {
  isSomething(): this is Something {
    return this instanceof Something;
  }
}

export type A = string | number;
```

Finally, the generated doc looks like:

![image](https://user-images.githubusercontent.com/23649474/123509689-e5ecf800-d6b1-11eb-937c-3320a4041eb1.png)

Ref: https://github.com/denoland/deno_doc/pull/105