### PR TITLE
Adds support for inline links

### DIFF
--- a/components/JSDoc.tsx
+++ b/components/JSDoc.tsx
@@ -17,8 +17,9 @@ export function JSDoc(props: { jsdoc: string }) {
   for (let i of jsdoc.split("\n")) {
     if (
       /^{@link .+}/g.test(i) &&
-      !/^{@link .+\|.+}/g.test(i) &&
-      !/{@link .+ .+}/g.test(i)
+      !/{@link .+\|.+}/g.test(i) &&
+      !/{@link .+ .+}/g.test(i) &&
+      !/\[.+\]{@link .+}/g.test(i)
     ) {
       // {@link https://www.link.com}
       const link = i.slice(7, i.length - 1);
@@ -29,7 +30,7 @@ export function JSDoc(props: { jsdoc: string }) {
       const text = splitString[0].slice(1);
       const link = splitString[1].slice(7, splitString[1].length - 1);
       jsdoc = jsdoc.replace(i, `\n\n[${text}](${link})`);
-    } else if (/^{@link .+\|.+}/g.test(i)) {
+    } else if (/{@link .+\|.+}/g.test(i)) {
       // {@link https://www.link.com|link text}
       const splitString = i.split("|");
       const text = splitString[1].slice(0, splitString[1].length - 1);

--- a/components/JSDoc.tsx
+++ b/components/JSDoc.tsx
@@ -26,9 +26,9 @@ export function JSDoc(props: { jsdoc: string }) {
       jsdoc = jsdoc.replace(i, `\n\n[${link}](${link})`);
     } else if (/\[.+\]{@link .+}/g.test(i)) {
       // [link text]{@link https://www.link.com}
-      const splitString = i.split("]");
-      const text = splitString[0].slice(1);
-      const link = splitString[1].slice(7, splitString[1].length - 1);
+      const splitString = i.split("{@link");
+      const text = splitString[0].slice(1, splitString[0].length - 1);
+      const link = splitString[1].slice(1, splitString[1].length - 1);
       jsdoc = jsdoc.replace(i, `\n\n[${text}](${link})`);
     } else if (/{@link .+\|.+}/g.test(i)) {
       // {@link https://www.link.com|link text}

--- a/components/JSDoc.tsx
+++ b/components/JSDoc.tsx
@@ -11,11 +11,15 @@ SyntaxHighlighter.registerLanguage("ts", typescript);
 export function JSDoc(props: { jsdoc: string }) {
   let jsdoc = props.jsdoc
     .replace(/\n@param/g, "\n\n __param__")
-    .replace(/\n@return/g, "\n\n __return__")
+    .replace(/\n@return/g, "\n\n __return__");
 
   // link inline tags
   for (let i of jsdoc.split("\n")) {
-    if (/^{@link .+}/g.test(i) && !(/^{@link .+\|.+}/g.test(i)) && !(/{@link .+ .+}/g.test(i))) {
+    if (
+      /^{@link .+}/g.test(i) &&
+      !/^{@link .+\|.+}/g.test(i) &&
+      !/{@link .+ .+}/g.test(i)
+    ) {
       // {@link https://www.link.com}
       const link = i.slice(7, i.length - 1);
       jsdoc = jsdoc.replace(i, `\n\n[${link}](${link})`);
@@ -33,14 +37,13 @@ export function JSDoc(props: { jsdoc: string }) {
       jsdoc = jsdoc.replace(i, `\n\n[${text}](${link})`);
     } else if (/{@link .+ .+}/g.test(i)) {
       // {@link https://www.link.com link text}
-      console.log("got here!")
       const splitString = i.split(" ");
-      const text = splitString.slice(2).join(" ")
+      const text = splitString.slice(2).join(" ");
       const link = splitString[1];
       jsdoc = jsdoc.replace(i, `\n\n[${text.slice(0, text.length - 1)}](${link})`);
     }
   }
-  
+
   return (
     <ReactMarkdown
       source={jsdoc}

--- a/components/JSDoc.tsx
+++ b/components/JSDoc.tsx
@@ -14,7 +14,6 @@ export function JSDoc(props: { jsdoc: string }) {
     .replace(/\n@return/g, "\n\n __return__")
     // [link text]{@link https://www.link.com}
     .replace(/\[(.*?)\]{@link (.*?)}/g, (match, text, link): string => {
-      console.log(match)
       return `[${text}](${link})`;
     })
     // {@link https://www.link.com|link text}
@@ -29,7 +28,7 @@ export function JSDoc(props: { jsdoc: string }) {
     .replace(/{@link (.*?)}/g, (match, link): string => {
       return `[${link}](${link})`
     })  
-
+  
   return (
     <ReactMarkdown
       source={jsdoc}

--- a/components/JSDoc.tsx
+++ b/components/JSDoc.tsx
@@ -11,41 +11,25 @@ SyntaxHighlighter.registerLanguage("ts", typescript);
 export function JSDoc(props: { jsdoc: string }) {
   let jsdoc = props.jsdoc
     .replace(/\n@param/g, "\n\n __param__")
-    .replace(/\n@return/g, "\n\n __return__");
-
-  // link inline tags
-  for (let i of jsdoc.split("\n")) {
-    if (
-      /{@link .+}/g.test(i) &&
-      !/{@link .+\|.+}/g.test(i) &&
-      !/{@link .+ .+}/g.test(i) &&
-      !/\[.+\]{@link .+}/g.test(i)
-    ) {
-      // {@link https://www.link.com}
-      const link = i.slice(7, i.length - 1);
-      jsdoc = jsdoc.replace(i, `\n\n[${link}](${link})`);
-    } else if (/\[.+\]{@link .+}/g.test(i)) {
-      // [link text]{@link https://www.link.com}
-      const splitString = i.split("{@link");
-      const text = splitString[0].slice(1, splitString[0].length - 1);
-      const link = splitString[1].slice(1, splitString[1].length - 1);
-      jsdoc = jsdoc.replace(i, `\n\n[${text}](${link})`);
-    } else if (/{@link .+\|.+}/g.test(i)) {
-      // {@link https://www.link.com|link text}
-      const splitString = i.split("|");
-      const text = splitString[1].slice(0, splitString[1].length - 1);
-      const link = splitString[0].slice(7);
-      jsdoc = jsdoc.replace(i, `\n\n[${text}](${link})`);
-    } else if (/{@link .+ .+}/g.test(i)) {
-      // {@link https://www.link.com link text}
-      const splitString = i.split(" ");
-      let text = splitString.slice(2).join(" ");
-      text = text.slice(0, text.length - 1)
-      const link = splitString[1];
-      jsdoc = jsdoc.replace(i, `\n\n[${text}](${link})`);
-    }
-  }
-
+    .replace(/\n@return/g, "\n\n __return__")
+    // [link text]{@link https://www.link.com}
+    .replace(/\[(.*?)\]{@link (.*?)}/g, (match, text, link): string => {
+      console.log(match)
+      return `[${text}](${link})`;
+    })
+    // {@link https://www.link.com|link text}
+    .replace(/{@link (.*?)\|(.*?)}/g, (match, link, text): string => {
+      return `[${text}](${link})`;
+    })
+    // {@link https://www.link.com link text}
+    .replace(/{@link (.*?) (.*?)}/g, (match, link, text): string => {
+      return `[${text}](${link})`
+    })
+    // {@link https://www.link.com}
+    .replace(/{@link (.*?)}/g, (match, link): string => {
+      return `[${link}](${link})`
+    })  
+  
   return (
     <ReactMarkdown
       source={jsdoc}

--- a/components/JSDoc.tsx
+++ b/components/JSDoc.tsx
@@ -39,9 +39,10 @@ export function JSDoc(props: { jsdoc: string }) {
     } else if (/{@link .+ .+}/g.test(i)) {
       // {@link https://www.link.com link text}
       const splitString = i.split(" ");
-      const text = splitString.slice(2).join(" ");
+      let text = splitString.slice(2).join(" ");
+      text = text.slice(0, text.length - 1)
       const link = splitString[1];
-      jsdoc = jsdoc.replace(i, `\n\n[${text.slice(0, text.length - 1)}](${link})`);
+      jsdoc = jsdoc.replace(i, `\n\n[${text}](${link})`);
     }
   }
 

--- a/components/JSDoc.tsx
+++ b/components/JSDoc.tsx
@@ -22,14 +22,14 @@ export function JSDoc(props: { jsdoc: string }) {
       return `[${text}](${link})`;
     })
     // {@link https://www.link.com link text}
-    .replace(/{@link (.*?) (.*?)}/g, (match, link, text): string => {
+    .replace(/{@link ([^}]*?) ([^}]*?)}/g, (match, link, text): string => {
       return `[${text}](${link})`
     })
     // {@link https://www.link.com}
     .replace(/{@link (.*?)}/g, (match, link): string => {
       return `[${link}](${link})`
     })  
-  
+
   return (
     <ReactMarkdown
       source={jsdoc}

--- a/components/JSDoc.tsx
+++ b/components/JSDoc.tsx
@@ -9,10 +9,38 @@ SyntaxHighlighter.registerLanguage("js", javascript);
 SyntaxHighlighter.registerLanguage("ts", typescript);
 
 export function JSDoc(props: { jsdoc: string }) {
-  const jsdoc = props.jsdoc
+  let jsdoc = props.jsdoc
     .replace(/\n@param/g, "\n\n __param__")
-    .replace(/\n@return/g, "\n\n __return__");
+    .replace(/\n@return/g, "\n\n __return__")
 
+  // link inline tags
+  for (let i of jsdoc.split("\n")) {
+    if (/^{@link .+}/g.test(i) && !(/^{@link .+\|.+}/g.test(i)) && !(/{@link .+ .+}/g.test(i))) {
+      // {@link https://www.link.com}
+      const link = i.slice(7, i.length - 1);
+      jsdoc = jsdoc.replace(i, `\n\n[${link}](${link})`);
+    } else if (/\[.+\]{@link .+}/g.test(i)) {
+      // [link text]{@link https://www.link.com}
+      const splitString = i.split("]");
+      const text = splitString[0].slice(1);
+      const link = splitString[1].slice(7, splitString[1].length - 1);
+      jsdoc = jsdoc.replace(i, `\n\n[${text}](${link})`);
+    } else if (/^{@link .+\|.+}/g.test(i)) {
+      // {@link https://www.link.com|link text}
+      const splitString = i.split("|");
+      const text = splitString[1].slice(0, splitString[1].length - 1);
+      const link = splitString[0].slice(7);
+      jsdoc = jsdoc.replace(i, `\n\n[${text}](${link})`);
+    } else if (/{@link .+ .+}/g.test(i)) {
+      // {@link https://www.link.com link text}
+      console.log("got here!")
+      const splitString = i.split(" ");
+      const text = splitString.slice(2).join(" ")
+      const link = splitString[1];
+      jsdoc = jsdoc.replace(i, `\n\n[${text.slice(0, text.length - 1)}](${link})`);
+    }
+  }
+  
   return (
     <ReactMarkdown
       source={jsdoc}

--- a/components/JSDoc.tsx
+++ b/components/JSDoc.tsx
@@ -16,7 +16,7 @@ export function JSDoc(props: { jsdoc: string }) {
   // link inline tags
   for (let i of jsdoc.split("\n")) {
     if (
-      /^{@link .+}/g.test(i) &&
+      /{@link .+}/g.test(i) &&
       !/{@link .+\|.+}/g.test(i) &&
       !/{@link .+ .+}/g.test(i) &&
       !/\[.+\]{@link .+}/g.test(i)


### PR DESCRIPTION
Demonstration available using this link: https://raw.githubusercontent.com/grian32/test/master/a.ts

Implemented all 4 `@link` types:
```js
{@link namepathOrURL}
[link text]{@link namepathOrURL}
{@link namepathOrURL|link text}
{@link namepathOrURL link text (after the first space)}
```
mentioned here: https://jsdoc.app/tags-inline-link.html