### PR TITLE
feat: add support for the deprecated tag

### DIFF
--- a/components/JSDoc.tsx
+++ b/components/JSDoc.tsx
@@ -27,7 +27,9 @@ export function JSDoc(props: { jsdoc: string }) {
     // {@link https://www.link.com}
     .replace(/{@link (.*?)}/g, (match, link): string => {
       return `[${link}](${link})`
-    })  
+    })
+    // @deprecated reason
+    .replace(/@deprecated/g, "__deprecated__");    
   
   return (
     <ReactMarkdown


### PR DESCRIPTION
This tag is used quite a bit in the runtime docs so I implemented it.

This change can be seen at https://doc-website-gwbc9x8ff-denoland.vercel.app/builtin/stable by CTRL+F `deprecated`