### PR TITLE
feat: support `@yields` and `@throws` tag blocks

### DIFF
--- a/components/JSDoc.tsx
+++ b/components/JSDoc.tsx
@@ -11,7 +11,10 @@ SyntaxHighlighter.registerLanguage("ts", typescript);
 export function JSDoc(props: { jsdoc: string }) {
   let jsdoc = props.jsdoc
     .replace(/\n@param/g, "\n\n __param__")
-    .replace(/\n@return/g, "\n\n __return__")
+    .replace(/\n@return(s?)/g, "\n\n __return$1__")
+    .replace(/\n@throws/g, "\n\n __throws__")
+    .replace(/\n@exception/g, "\n\n __exception__")
+    .replace(/\n@yield(s?)/g, "\n\n __yield$1__")
     // [link text]{@link https://www.link.com}
     .replace(/\[(.*?)\]{@link (.*?)}/g, (match, text, link): string => {
       return `[${text}](${link})`;


### PR DESCRIPTION
Fixes #225
Fixes #151

Adds the following to syntax highlighted JSDoc tag blocks:

- `@returns`
- `@yields`
- `@yield`
- `@throws`
- `@exception`

See https://doc-website-m9hog6kqk-denoland.vercel.app for testing, e.g. https://doc-website-m9hog6kqk-denoland.vercel.app/https/raw.githubusercontent.com%2Fdenoland%2Fdeno_std%2F0fc3b2e75e73892a8f4310798584bf052ba34dd0%2Fhttp%2Fserver.ts.

![Deno docs method with `@throws` JSDoc tag being highlighted in bold](https://user-images.githubusercontent.com/11313985/131880790-2b06f750-137e-48b8-be91-6bb1a0b4ccda.png)
