### PR TITLE
chore: update Deno version to 1.14.1

### DIFF
--- a/api/docs.ts
+++ b/api/docs.ts
@@ -36,7 +36,7 @@ export default async (req: ServerRequest) => {
   // Zeit timeout is 60 seconds for pro tier: https://zeit.co/docs/v2/platform/limits
   const timer = setTimeout(() => {
     killed = true;
-    proc.kill(Deno.Signal.SIGKILL);
+    proc.kill("SIGKILL");
   }, 58000);
 
   const [out, errOut] = await Promise.all([proc.output(), proc.stderrOutput()]);

--- a/components/JSDoc.tsx
+++ b/components/JSDoc.tsx
@@ -29,8 +29,8 @@ export function JSDoc(props: { jsdoc: string }) {
       return `[${link}](${link})`
     })
     // @deprecated reason
-    .replace(/@deprecated/g, "__deprecated__");    
-  
+    .replace(/@deprecated/g, "__deprecated__");
+
   return (
     <ReactMarkdown
       source={jsdoc}

--- a/components/SinglePage.tsx
+++ b/components/SinglePage.tsx
@@ -307,9 +307,9 @@ export function SimpleCard({
         </a>
       </div>
 
-      {node.jsDoc ? (
+      {node.jsDoc?.doc ? (
         <div className="mt-2 text-xs text-gray-900 dark:text-gray-200">
-          <JSDoc jsdoc={node.jsDoc} />
+          <JSDoc jsdoc={node.jsDoc.doc} />
         </div>
       ) : null}
 
@@ -384,9 +384,9 @@ export function SimpleSubCard({
           </a>
         ) : null}
       </div>
-      {node.jsDoc ? (
+      {node.jsDoc?.doc ? (
         <div className="mt-1 text-xs">
-          <JSDoc jsdoc={node.jsDoc} />
+          <JSDoc jsdoc={node.jsDoc.doc} />
         </div>
       ) : null}
     </div>

--- a/util/docs.ts
+++ b/util/docs.ts
@@ -21,7 +21,7 @@ export interface DocNodeShared {
   name: string;
   scope?: string[];
   location: DocNodeLocation;
-  jsDoc?: string;
+  jsDoc?: { doc?: string, tags?: string[] };
 }
 export interface TsTypeParamDef {
   name: string;
@@ -716,7 +716,7 @@ export function getFieldsForClassRecursive(
 
 export function normalizeFilename(filename: string): string {
   const rawRegex = /(github\.com\/.+\/.+\/|gitlab\.com\/.+\/.+\/-\/)raw/
-  const usercontentRegex = /raw\.githubusercontent\.com\/([^\/]+\/[^\/]+)/ 
+  const usercontentRegex = /raw\.githubusercontent\.com\/([^\/]+\/[^\/]+)/
   if (filename.match(rawRegex)) {
     return filename.replace(rawRegex, "$1blob")
   }
@@ -727,4 +727,3 @@ export function normalizeFilename(filename: string): string {
 
   return filename
 }
-

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
   "regions": ["sfo"],
   "build": {
     "env": {
-      "DENO_VERSION": "1.12.2",
+      "DENO_VERSION": "1.14.1",
       "DENO_UNSTABLE": "true"
     }
   },


### PR DESCRIPTION
Haven't tried using 1.14.2 because it looks like it isn't supported yet: https://github.com/hayd/deno-lambda/releases

This PR also removes some trailing whitespace - not intentionally, just `deno fmt` being `deno fmt` :P